### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "presonus-studiolive-api-midi-integration",
+  "version": "1.0.0",
   "scripts": {
     "dev": "sapper dev | bunyan",
     "build": "sapper build --legacy",


### PR DESCRIPTION
adding "version": "1.0.0",

fix yarn add:

yarn add featherbear/presonus-studiolive-api-midi-integration      
yarn add v1.22.19
warning package.json: No license field
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
warning No license field
[1/4] 🔍  Resolving packages...
**_error Can't add "presonus-studiolive-api-midi-integration": invalid package version undefined._**
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.


